### PR TITLE
Avoid ArgumentNullException from Regex.Match when default value is null

### DIFF
--- a/Cake.Tfs.Build.Variables.Tests/ValueEvaluatorTests.cs
+++ b/Cake.Tfs.Build.Variables.Tests/ValueEvaluatorTests.cs
@@ -30,6 +30,14 @@ namespace Cake.Tfs.Build.Variables.Tests
         }
 
         [Fact]
+        public void NonExistentValueWithNullDefaultValueTest()
+        {
+            var c = new TestCakeContext();
+            var value = TfsBuildVariablesAliases.EvaluateTfsBuildVariable(c, "Cake.Variables.Test", null);
+            Assert.Null(value);
+        }
+
+        [Fact]
         public void ValueFromEnvTest()
         {
             Dictionary<string, string> envVars = new Dictionary<string, string>() { { "CAKE_VARIABLES_TEST", "testenvvalue" } };

--- a/Cake.Tfs.Build.Variables/ValueEvaluator.cs
+++ b/Cake.Tfs.Build.Variables/ValueEvaluator.cs
@@ -130,7 +130,10 @@ namespace Cake.Tfs.Build.Variables
         {
             string value = EvaluateVariable(context, variableName, defaultValue);
 
-            value = SubstituteNestedVariable(context, value);
+            if (value != null)
+            {
+                value = SubstituteNestedVariable(context, value);
+            }
 
             return value;
         }


### PR DESCRIPTION
I was trying to do something like:

```C#
string foo = Argument<string>("foo", defaultValue: null)
          ?? EvaluateTfsBuildVariable("BuildFoo", defaultValue: null)
          ?? "bar";
```

But that was generating the following exception:

    System.ArgumentNullException: Value cannot be null.
    Parameter name: input
       at System.Text.RegularExpressions.Regex.Match(String input)
       at System.Text.RegularExpressions.Regex.Match(String input, String pattern)
       at Cake.Tfs.Build.Variables.TfsBuildVariablesAliases.SubstituteNestedVariable(ICakeContext context, String value)
       at Cake.Tfs.Build.Variables.TfsBuildVariablesAliases.EvaluateTfsBuildVariable(ICakeContext context, String variableName, String defaultValue)

This fixes that.